### PR TITLE
ls コマンドを作るオブジェクト指向版

### DIFF
--- a/07.ls_object/directory.rb
+++ b/07.ls_object/directory.rb
@@ -3,12 +3,14 @@
 require_relative 'entry'
 
 class Directory
+  attr_reader :entries
+
   def initialize(directory_path)
     @path = directory_path
   end
 
   def generate_list_content(opt_param)
-    @entries =
-      Dir.entries(@path).map { |entry| Entry.new(path, entry) }
+    @entries = Dir.entries(@path).map { |entry| Entry.new(@path, entry) }
+    FormatterFactory.create(opt_param).generate_formatted_content(self, opt_param)
   end
 end

--- a/07.ls_object/directory.rb
+++ b/07.ls_object/directory.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Directory
+  def initialize(directory_path)
+    @path = directory_path
+  end
+
+  def generate_list_content(opt_param)
+  end
+end

--- a/07.ls_object/directory.rb
+++ b/07.ls_object/directory.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'entry'
+require_relative 'formatter_factory'
 
 class Directory
   attr_reader :entries, :path
@@ -10,7 +11,25 @@ class Directory
   end
 
   def generate_list_content(opt_param)
-    @entries = Dir.entries(path).map { |entry| Entry.new([path, entry].join('/'), entry) }
-    FormatterFactory.create(opt_param).generate_formatted_content(self, opt_param)
+    @entries = generate_entries_by_options(opt_param)
+    FormatterFactory.create(self, opt_param).generate_formatted_content
+  end
+
+  private
+
+  def generate_entries_by_options(opt_param)
+    entries = Dir.entries(path).map { |entry| Entry.new([path, entry].join('/'), entry) }
+    filtered_entries =
+      if opt_param.show_all?
+        entries
+      else
+        entries.reject { |entry| entry.display_name[0] == '.' }
+      end
+
+    if opt_param.sort_reverse?
+      filtered_entries.sort_by(&:display_name).reverse
+    else
+      filtered_entries.sort_by(&:display_name)
+    end
   end
 end

--- a/07.ls_object/directory.rb
+++ b/07.ls_object/directory.rb
@@ -30,10 +30,7 @@ class Directory
   end
 
   def sort_entries(unsorted_entries, opt_param)
-    if opt_param.sort_reverse?
-      unsorted_entries.sort_by(&:display_name).reverse
-    else
-      unsorted_entries.sort_by(&:display_name)
-    end
+    sorted_entries = unsorted_entries.sort_by(&:display_name)
+    opt_param.sort_reverse? ? sorted_entries.reverse : sorted_entries
   end
 end

--- a/07.ls_object/directory.rb
+++ b/07.ls_object/directory.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
+require_relative 'entry'
+
 class Directory
   def initialize(directory_path)
     @path = directory_path
   end
 
   def generate_list_content(opt_param)
+    @entries =
+      Dir.entries(@path).map { |entry| Entry.new(path, entry) }
   end
 end

--- a/07.ls_object/directory.rb
+++ b/07.ls_object/directory.rb
@@ -3,14 +3,14 @@
 require_relative 'entry'
 
 class Directory
-  attr_reader :entries
+  attr_reader :entries, :path
 
   def initialize(directory_path)
     @path = directory_path
   end
 
   def generate_list_content(opt_param)
-    @entries = Dir.entries(@path).map { |entry| Entry.new([@path, entry].join('/'), entry) }
+    @entries = Dir.entries(path).map { |entry| Entry.new([path, entry].join('/'), entry) }
     FormatterFactory.create(opt_param).generate_formatted_content(self, opt_param)
   end
 end

--- a/07.ls_object/directory.rb
+++ b/07.ls_object/directory.rb
@@ -25,7 +25,7 @@ class Directory
     if opt_param.show_all?
       unfiltered_entries
     else
-      unfiltered_entries.reject { |entry| entry.display_name[0] == '.' }
+      unfiltered_entries.reject { |entry| entry.display_name.start_with?('.') }
     end
   end
 

--- a/07.ls_object/directory.rb
+++ b/07.ls_object/directory.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative 'entry'
-require_relative 'formatter_factory'
 
 class Directory
   attr_reader :entries, :path
@@ -10,26 +9,20 @@ class Directory
     @path = directory_path
   end
 
-  def generate_list_content(opt_param)
-    @entries = generate_entries_by_options(opt_param)
-    FormatterFactory.create(self, opt_param).generate_formatted_content
-  end
-
-  private
-
-  def generate_entries_by_options(opt_param)
-    entries = Dir.entries(path).map { |entry| Entry.new([path, entry].join('/'), entry) }
+  def generate_entries(opt_param)
+    row_entries = Dir.entries(path).map { |entry| Entry.new([path, entry].join('/'), entry) }
     filtered_entries =
       if opt_param.show_all?
-        entries
+        row_entries
       else
-        entries.reject { |entry| entry.display_name[0] == '.' }
+        row_entries.reject { |entry| entry.display_name[0] == '.' }
       end
 
-    if opt_param.sort_reverse?
-      filtered_entries.sort_by(&:display_name).reverse
-    else
-      filtered_entries.sort_by(&:display_name)
-    end
+    @entries =
+      if opt_param.sort_reverse?
+        filtered_entries.sort_by(&:display_name).reverse
+      else
+        filtered_entries.sort_by(&:display_name)
+      end
   end
 end

--- a/07.ls_object/directory.rb
+++ b/07.ls_object/directory.rb
@@ -15,18 +15,25 @@ class Directory
 
   def generate_entries(opt_param)
     row_entries = Dir.entries(path).map { |entry| Entry.new([path, entry].join('/'), entry) }
-    filtered_entries =
-      if opt_param.show_all?
-        row_entries
-      else
-        row_entries.reject { |entry| entry.display_name[0] == '.' }
-      end
+    filtered_entries = filter_entries(row_entries, opt_param)
+    @entries = sort_entries(filtered_entries, opt_param)
+  end
 
-    @entries =
-      if opt_param.sort_reverse?
-        filtered_entries.sort_by(&:display_name).reverse
-      else
-        filtered_entries.sort_by(&:display_name)
-      end
+  private
+
+  def filter_entries(unfiltered_entries, opt_param)
+    if opt_param.show_all?
+      unfiltered_entries
+    else
+      unfiltered_entries.reject { |entry| entry.display_name[0] == '.' }
+    end
+  end
+
+  def sort_entries(unsorted_entries, opt_param)
+    if opt_param.sort_reverse?
+      unsorted_entries.sort_by(&:display_name).reverse
+    else
+      unsorted_entries.sort_by(&:display_name)
+    end
   end
 end

--- a/07.ls_object/directory.rb
+++ b/07.ls_object/directory.rb
@@ -10,7 +10,7 @@ class Directory
   end
 
   def generate_list_content(opt_param)
-    @entries = Dir.entries(@path).map { |entry| Entry.new(@path, entry) }
+    @entries = Dir.entries(@path).map { |entry| Entry.new([@path, entry].join('/'), entry) }
     FormatterFactory.create(opt_param).generate_formatted_content(self, opt_param)
   end
 end

--- a/07.ls_object/directory.rb
+++ b/07.ls_object/directory.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
 require_relative 'entry'
+require_relative 'statistics'
 
 class Directory
-  attr_reader :entries, :path
+  include Statistics
+
+  attr_reader :entries, :disp_total, :path
 
   def initialize(directory_path)
     @path = directory_path
+    @disp_total = true
   end
 
   def generate_entries(opt_param)

--- a/07.ls_object/entry.rb
+++ b/07.ls_object/entry.rb
@@ -9,7 +9,7 @@ class Entry
   include FileType
   include FilePermission
 
-  attr_reader :path
+  attr_reader :path, :display_name
 
   def initialize(path, display_name = nil)
     @path = path

--- a/07.ls_object/entry.rb
+++ b/07.ls_object/entry.rb
@@ -9,6 +9,8 @@ class Entry
   include FileType
   include FilePermission
 
+  attr_reader :path
+
   def initialize(path, display_name = nil)
     @path = path
     @display_name = display_name || path
@@ -19,7 +21,7 @@ class Entry
 
   def permission = get_perission(file_stat.mode)
 
-  def macxattr = MacXattr.new.get_macxattr(@path)
+  def macxattr = MacXattr.new.get_macxattr(@ath)
 
   def nlink = file_stat.nlink
 
@@ -32,7 +34,7 @@ class Entry
   def modified_time = file_stat.mtime
 
   def symbolic_link
-    symbolic_link? ? File.readlink(@path) : nil
+    symbolic_link? ? File.readlink(path) : nil
   end
 
   def symbolic_link? = file_stat.symlink?

--- a/07.ls_object/entry.rb
+++ b/07.ls_object/entry.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'etc'
+require 'macxattr' # mac拡張属性取得用の拡張ライブラリ
+require_relative 'file_type'
+require_relative 'file_permission'
+
+class Entry
+  include FileType
+  include FilePermission
+
+  def initialize(path, display_name)
+    @path = path
+    @display_name = display_name
+    @file_stat = File.lstat(path)
+  end
+
+  def file_type = get_file_type(file_stat.mode)
+
+  def permission = get_perission(file_stat.mode)
+
+  def macxattr = MacXattr.new.get_macxattr(full_path)
+
+  def nlink = file_stat.nlink
+
+  def owner_name = Etc.getpwuid(file_stat.uid).name
+
+  def group_name = Etc.getgrgid(file_stat.gid).name
+
+  def file_size = file_stat.size
+
+  def modified_time = file_stat.mtime
+
+  def symbolic_link
+    symbolic_link? ? File.readlink(full_path) : nil
+  end
+
+  def symbolic_link? = file_stat.symlink?
+
+  def blocks = file_stat.blocks
+
+  private
+
+  attr_reader :file_stat
+end

--- a/07.ls_object/entry.rb
+++ b/07.ls_object/entry.rb
@@ -12,7 +12,7 @@ class Entry
   def initialize(path, display_name = nil)
     @path = path
     @display_name = display_name || path
-    @file_stat = File.lstat(path)
+    @file_stat = File.lstat(path) if File.exist?(path)
   end
 
   def file_type = get_file_type(file_stat.mode)

--- a/07.ls_object/entry.rb
+++ b/07.ls_object/entry.rb
@@ -9,9 +9,9 @@ class Entry
   include FileType
   include FilePermission
 
-  def initialize(path, display_name)
+  def initialize(path, display_name = nil)
     @path = path
-    @display_name = display_name
+    @display_name = display_name || path
     @file_stat = File.lstat(path)
   end
 

--- a/07.ls_object/entry.rb
+++ b/07.ls_object/entry.rb
@@ -21,7 +21,7 @@ class Entry
 
   def permission = get_perission(file_stat.mode)
 
-  def macxattr = MacXattr.new.get_macxattr(@ath)
+  def macxattr = MacXattr.new.get_macxattr(@path)
 
   def nlink = file_stat.nlink
 

--- a/07.ls_object/entry.rb
+++ b/07.ls_object/entry.rb
@@ -19,7 +19,7 @@ class Entry
 
   def permission = get_perission(file_stat.mode)
 
-  def macxattr = MacXattr.new.get_macxattr(full_path)
+  def macxattr = MacXattr.new.get_macxattr(@path)
 
   def nlink = file_stat.nlink
 
@@ -32,7 +32,7 @@ class Entry
   def modified_time = file_stat.mtime
 
   def symbolic_link
-    symbolic_link? ? File.readlink(full_path) : nil
+    symbolic_link? ? File.readlink(@path) : nil
   end
 
   def symbolic_link? = file_stat.symlink?

--- a/07.ls_object/entry.rb
+++ b/07.ls_object/entry.rb
@@ -17,31 +17,27 @@ class Entry
     @file_stat = File.lstat(path) if File.exist?(path)
   end
 
-  def file_type = get_file_type(file_stat.mode)
+  def file_type = get_file_type(@file_stat.mode)
 
-  def permission = get_perission(file_stat.mode)
+  def permission = get_perission(@file_stat.mode)
 
   def macxattr = MacXattr.new.get_macxattr(@path)
 
-  def nlink = file_stat.nlink
+  def nlink = @file_stat.nlink
 
-  def owner_name = Etc.getpwuid(file_stat.uid).name
+  def owner_name = Etc.getpwuid(@file_stat.uid).name
 
-  def group_name = Etc.getgrgid(file_stat.gid).name
+  def group_name = Etc.getgrgid(@file_stat.gid).name
 
-  def file_size = file_stat.size
+  def file_size = @file_stat.size
 
-  def modified_time = file_stat.mtime
+  def modified_time = @file_stat.mtime
 
   def symbolic_link
     symbolic_link? ? File.readlink(path) : nil
   end
 
-  def symbolic_link? = file_stat.symlink?
+  def symbolic_link? = @file_stat.symlink?
 
-  def blocks = file_stat.blocks
-
-  private
-
-  attr_reader :file_stat
+  def blocks = @file_stat.blocks
 end

--- a/07.ls_object/extconf.rb
+++ b/07.ls_object/extconf.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require 'mkmf'
+create_makefile('macxattr')

--- a/07.ls_object/file_permission.rb
+++ b/07.ls_object/file_permission.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module FilePermission
+  DIGITS_OCTAL_TO_BINARY = 3
+
+  module PermissionMask
+    READABLE    = 0o4
+    WRITABLE    = 0o2
+    EXECUTABLE  = 0o1
+  end
+
+  module PermissionUser
+    OWNER = 0o700
+    GROUP = 0o070
+    OTHER = 0o007
+  end
+
+  def get_perission(mode)
+    owner_permission = get_permission_attr((mode & PermissionUser::OWNER) >> 2 * DIGITS_OCTAL_TO_BINARY)
+    group_permission = get_permission_attr((mode & PermissionUser::GROUP) >> 1 * DIGITS_OCTAL_TO_BINARY)
+    other_permission = get_permission_attr((mode & PermissionUser::OTHER) >> 0 * DIGITS_OCTAL_TO_BINARY)
+    [owner_permission, group_permission, other_permission].join
+  end
+
+  def get_permission_attr(permission_bits)
+    permission_masks = {
+      PermissionMask::READABLE => 'r',
+      PermissionMask::WRITABLE => 'w',
+      PermissionMask::EXECUTABLE => 'x'
+    }
+    permission_masks.each_with_object(+'') do |(mask, attr), permission|
+      permission << (mask & permission_bits != 0 ? attr : '-')
+    end
+  end
+end

--- a/07.ls_object/file_type.rb
+++ b/07.ls_object/file_type.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module FileType
+  S_IFMT   = 0o170000 # bit mask for the file type bit field
+  S_IFSOCK = 0o140000 # socket
+  S_IFLNK  = 0o120000 # symbolic link
+  S_IFREG  = 0o100000 # regular file
+  S_IFBLK  = 0o060000 # block device
+  S_IFDIR  = 0o040000 # directory
+  S_IFCHR  = 0o020000 # character device
+  S_IFIFO  = 0o010000 # FIFO
+
+  def get_file_type(mode)
+    case FileType::S_IFMT & mode
+    when FileType::S_IFSOCK then 's'
+    when FileType::S_IFLNK  then 'l'
+    when FileType::S_IFREG  then '-'
+    when FileType::S_IFBLK  then 'b'
+    when FileType::S_IFDIR  then 'd'
+    when FileType::S_IFCHR  then 'c'
+    when FileType::S_IFIFO  then 'p'
+    end
+  end
+end

--- a/07.ls_object/formatter_factory.rb
+++ b/07.ls_object/formatter_factory.rb
@@ -9,7 +9,7 @@ class FormatterFactory
     return NonExistentFormatter.new(container.entries) if container.instance_of?(NonExistentContainer)
 
     if opt_param.long_format?
-      LongFormatter.new(container.entries)
+      LongFormatter.new(container.entries, container.generate_statistics, container.disp_total)
     else
       ShortFormatter.new(container.entries)
     end

--- a/07.ls_object/formatter_factory.rb
+++ b/07.ls_object/formatter_factory.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative 'non_existent_formatter'
+require_relative 'long_formatter'
+require_relative 'short_formatter'
+
+class FormatterFactory
+  def self.create(opt_param, non_existent = false)
+    return NonExistentFormatter.new if non_existent
+
+    opt_param.long_format? ? LongFormatter.new(opt_param) : ShortFormatter.new(opt_param)
+  end
+end

--- a/07.ls_object/formatter_factory.rb
+++ b/07.ls_object/formatter_factory.rb
@@ -5,9 +5,13 @@ require_relative 'long_formatter'
 require_relative 'short_formatter'
 
 class FormatterFactory
-  def self.create(opt_param, non_existent: false)
-    return NonExistentFormatter.new if non_existent
+  def self.create(container, opt_param)
+    return NonExistentFormatter.new(container.entries) if container.instance_of?(NonExistentContainer)
 
-    opt_param.long_format? ? LongFormatter.new : ShortFormatter.new
+    if opt_param.long_format?
+      LongFormatter.new(container.entries)
+    else
+      ShortFormatter.new(container.entries)
+    end
   end
 end

--- a/07.ls_object/formatter_factory.rb
+++ b/07.ls_object/formatter_factory.rb
@@ -5,9 +5,9 @@ require_relative 'long_formatter'
 require_relative 'short_formatter'
 
 class FormatterFactory
-  def self.create(opt_param, non_existent = false)
+  def self.create(opt_param, non_existent: false)
     return NonExistentFormatter.new if non_existent
 
-    opt_param.long_format? ? LongFormatter.new(opt_param) : ShortFormatter.new(opt_param)
+    opt_param.long_format? ? LongFormatter.new : ShortFormatter.new
   end
 end

--- a/07.ls_object/long_formatter.rb
+++ b/07.ls_object/long_formatter.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class LongFormatter
+  def initialize(opt_param)
+    @opt_param = opt_param
+  end
+end

--- a/07.ls_object/long_formatter.rb
+++ b/07.ls_object/long_formatter.rb
@@ -1,28 +1,24 @@
 # frozen_string_literal: true
 
 class LongFormatter
-  def initialize(entries)
+  def initialize(entries, statistics, disp_total)
     @entries = entries
+    @statistics = statistics
+    @disp_total = disp_total
   end
 
   def generate_formatted_content
-    nlink_length = entries.map(&:nlink).max.to_s.length
-    owner_name_length = entries.map(&:owner_name).max_by(&:length).length
-    group_name_length = entries.map(&:group_name).max_by(&:length).length
-    file_size_length = entries.map(&:file_size).max.to_s.length
-    total_blocks = entries.sum(&:blocks)
-
     delimiter = ' '
-    result_content = ["total #{total_blocks}"]
+    result_content = disp_total ? ["total #{statistics.total_block_size}"] : []
     entries.each_with_object(result_content) do |entry, result|
       result.push([
         entry.file_type,
         entry.permission,
         entry.macxattr + delimiter,
-        entry.nlink.to_s.rjust(nlink_length) + delimiter,
-        entry.owner_name.ljust(owner_name_length) + delimiter * 2,
-        entry.group_name.ljust(group_name_length) + delimiter * 2,
-        entry.file_size.to_s.rjust(file_size_length) + delimiter,
+        entry.nlink.to_s.rjust(statistics.nlink_length) + delimiter,
+        entry.owner_name.ljust(statistics.owner_name_length) + delimiter * 2,
+        entry.group_name.ljust(statistics.group_name_length) + delimiter * 2,
+        entry.file_size.to_s.rjust(statistics.file_size_length) + delimiter,
         get_modified_time_string(entry.modified_time) + delimiter,
         entry.symbolic_link? ? [entry.display_name, ' -> ', entry.symbolic_link].join : entry.display_name
       ].join)
@@ -31,7 +27,7 @@ class LongFormatter
 
   private
 
-  attr_reader :entries
+  attr_reader :entries, :statistics, :disp_total
 
   def get_modified_time_string(time)
     if time.year == Time.now.year

--- a/07.ls_object/long_formatter.rb
+++ b/07.ls_object/long_formatter.rb
@@ -8,20 +8,9 @@ class LongFormatter
   end
 
   def generate_formatted_content
-    delimiter = ' '
-    result_content = disp_total ? ["total #{statistics.total_block_size}"] : []
-    entries.each_with_object(result_content) do |entry, result|
-      result.push([
-        entry.file_type,
-        entry.permission,
-        entry.macxattr + delimiter,
-        entry.nlink.to_s.rjust(statistics.nlink_length) + delimiter,
-        entry.owner_name.ljust(statistics.owner_name_length) + delimiter * 2,
-        entry.group_name.ljust(statistics.group_name_length) + delimiter * 2,
-        entry.file_size.to_s.rjust(statistics.file_size_length) + delimiter,
-        get_modified_time_string(entry.modified_time) + delimiter,
-        entry.symbolic_link? ? [entry.display_name, ' -> ', entry.symbolic_link].join : entry.display_name
-      ].join)
+    contents = disp_total ? ["total #{statistics.total_block_size}"] : []
+    entries.each_with_object(contents) do |entry, results|
+      results << format_entry(entry)
     end.join("\n")
   end
 
@@ -29,7 +18,22 @@ class LongFormatter
 
   attr_reader :entries, :statistics, :disp_total
 
-  def get_modified_time_string(time)
+  def format_entry(entry)
+    delimiter = ' '
+    [
+      entry.file_type,
+      entry.permission,
+      entry.macxattr + delimiter,
+      entry.nlink.to_s.rjust(statistics.nlink_length) + delimiter,
+      entry.owner_name.ljust(statistics.owner_name_length) + delimiter * 2,
+      entry.group_name.ljust(statistics.group_name_length) + delimiter * 2,
+      entry.file_size.to_s.rjust(statistics.file_size_length) + delimiter,
+      format_modified_time(entry.modified_time) + delimiter,
+      entry.symbolic_link? ? [entry.display_name, ' -> ', entry.symbolic_link].join : entry.display_name
+    ].join
+  end
+
+  def format_modified_time(time)
     if time.year == Time.now.year
       time.strftime('%_2m %_2d %H:%M')
     else

--- a/07.ls_object/long_formatter.rb
+++ b/07.ls_object/long_formatter.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class LongFormatter
+  def initialize(entries)
+    @entries = entries
+  end
 
-  def generate_formatted_content(container, opt_param)
-    entries = generate_entries(container, opt_param)
-
+  def generate_formatted_content
     nlink_length = entries.map(&:nlink).max.to_s.length
     owner_name_length = entries.map(&:owner_name).max_by(&:length).length
     group_name_length = entries.map(&:group_name).max_by(&:length).length
@@ -28,20 +29,11 @@ class LongFormatter
         ].join)
     end.join("\n")
   end
-  
+
   private
 
-  def generate_entries(container, opt_param)
-    entries =
-      if opt_param.show_all?
-        container.entries.dup
-      else
-        container.entries.reject { |entry| entry.display_name[0] == '.' }
-      end
+  attr_reader :entries
 
-    opt_param.sort_reverse? ? entries.sort_by(&:display_name).reverse : entries.sort_by(&:display_name)
-  end
-  
   def get_modified_time_string(time)
     if time.year == Time.now.year
       time.strftime('%_2m %_2d %H:%M')

--- a/07.ls_object/long_formatter.rb
+++ b/07.ls_object/long_formatter.rb
@@ -1,7 +1,52 @@
 # frozen_string_literal: true
 
 class LongFormatter
-  def initialize(opt_param)
-    @opt_param = opt_param
+
+  def generate_formatted_content(container, opt_param)
+    entries = generate_entries(container, opt_param)
+
+    nlink_length = entries.map(&:nlink).max.to_s.length
+    owner_name_length = entries.map(&:owner_name).max_by(&:length).length
+    group_name_length = entries.map(&:group_name).max_by(&:length).length
+    file_size_length = entries.map(&:file_size).max.to_s.length
+    total_blocks = entries.sum(&:blocks)
+
+    delimiter = ' '
+    result_content = ["total #{total_blocks}"]
+    entries.each_with_object(result_content) do |entry, result|
+      result.push(
+        [
+          entry.file_type,
+          entry.permission,
+          entry.macxattr + delimiter,
+          entry.nlink.to_s.rjust(nlink_length) + delimiter,
+          entry.owner_name.ljust(owner_name_length) + delimiter * 2,
+          entry.group_name.ljust(group_name_length) + delimiter * 2,
+          entry.file_size.to_s.rjust(file_size_length) + delimiter,
+          get_modified_time_string(entry.modified_time) + delimiter,
+          entry.symbolic_link? ? [entry.display_name, ' -> ', entry.symbolic_link].join : entry.display_name
+        ].join)
+    end.join("\n")
+  end
+  
+  private
+
+  def generate_entries(container, opt_param)
+    entries =
+      if opt_param.show_all?
+        container.entries.dup
+      else
+        container.entries.reject { |entry| entry.display_name[0] == '.' }
+      end
+
+    opt_param.sort_reverse? ? entries.sort_by(&:display_name).reverse : entries.sort_by(&:display_name)
+  end
+  
+  def get_modified_time_string(time)
+    if time.year == Time.now.year
+      time.strftime('%_2m %_2d %H:%M')
+    else
+      time.strftime('%_2m %_2d  %Y')
+    end
   end
 end

--- a/07.ls_object/long_formatter.rb
+++ b/07.ls_object/long_formatter.rb
@@ -15,18 +15,17 @@ class LongFormatter
     delimiter = ' '
     result_content = ["total #{total_blocks}"]
     entries.each_with_object(result_content) do |entry, result|
-      result.push(
-        [
-          entry.file_type,
-          entry.permission,
-          entry.macxattr + delimiter,
-          entry.nlink.to_s.rjust(nlink_length) + delimiter,
-          entry.owner_name.ljust(owner_name_length) + delimiter * 2,
-          entry.group_name.ljust(group_name_length) + delimiter * 2,
-          entry.file_size.to_s.rjust(file_size_length) + delimiter,
-          get_modified_time_string(entry.modified_time) + delimiter,
-          entry.symbolic_link? ? [entry.display_name, ' -> ', entry.symbolic_link].join : entry.display_name
-        ].join)
+      result.push([
+        entry.file_type,
+        entry.permission,
+        entry.macxattr + delimiter,
+        entry.nlink.to_s.rjust(nlink_length) + delimiter,
+        entry.owner_name.ljust(owner_name_length) + delimiter * 2,
+        entry.group_name.ljust(group_name_length) + delimiter * 2,
+        entry.file_size.to_s.rjust(file_size_length) + delimiter,
+        get_modified_time_string(entry.modified_time) + delimiter,
+        entry.symbolic_link? ? [entry.display_name, ' -> ', entry.symbolic_link].join : entry.display_name
+      ].join)
     end.join("\n")
   end
 

--- a/07.ls_object/ls.rb
+++ b/07.ls_object/ls.rb
@@ -7,36 +7,41 @@ require_relative 'unrelated_file_container'
 require_relative 'directory'
 require_relative 'formatter_factory'
 
-def main
-  opt_param = OptionalParameter.new
-
-  paths = ARGV.empty? ? [Dir.pwd] : ARGV.sort
-  existent_paths, nonexistent_paths = paths.partition { |path| File.exist?(path) }
-  directory_paths, file_paths = existent_paths.partition { |path| File.ftype(path) == 'directory' }
-
-  sorted_file_paths = sort_with_reverse_option(file_paths, opt_param.sort_reverse?)
-  sorted_directory_paths = sort_with_reverse_option(directory_paths, opt_param.sort_reverse?)
-
-  containers = []
-  containers << NonExistentContainer.new(nonexistent_paths) if nonexistent_paths.any?
-  containers << UnrelatedFileContainer.new(sorted_file_paths) if sorted_file_paths.any?
-  sorted_directory_paths.each do |directory_path|
-    containers << Directory.new(directory_path)
+class LS
+  def initialize
+    @opt_param = OptionalParameter.new
+    @paths = ARGV.empty? ? [Dir.pwd] : ARGV.sort
   end
 
-  result =
-    containers.each_with_object([]).with_index do |(container, result), index|
+  def generate_content
+    generate_containers.each_with_object([]) do |container, result|
       container.generate_entries(opt_param)
-      result << "#{container.path}:" if container.instance_of?(Directory)
+      result << "\n#{container.path}:" if container.instance_of?(Directory)
       result << FormatterFactory.create(container, opt_param).generate_formatted_content
-      result << "\n" if !container.instance_of?(NonExistentContainer) && index != containers.size - 1
+    end.join("\n")
+  end
+
+  private
+
+  attr_reader :opt_param, :paths
+
+  def sort_with_reverse_option(paths, reverse)
+    reverse ? paths.sort.reverse : paths.sort
+  end
+
+  def generate_containers
+    existent_paths, nonexistent_paths = paths.partition { |path| File.exist?(path) }
+    directory_paths, file_paths = existent_paths.partition { |path| File.ftype(path) == 'directory' }
+    sorted_file_paths = sort_with_reverse_option(file_paths, opt_param.sort_reverse?)
+    sorted_directory_paths = sort_with_reverse_option(directory_paths, opt_param.sort_reverse?)
+
+    containers = []
+    containers << NonExistentContainer.new(nonexistent_paths) if nonexistent_paths.any?
+    containers << UnrelatedFileContainer.new(sorted_file_paths) if sorted_file_paths.any?
+    sorted_directory_paths.each_with_object(containers) do |directory_path, result|
+      result << Directory.new(directory_path)
     end
-
-  puts result
+  end
 end
 
-def sort_with_reverse_option(paths, reverse)
-  reverse ? paths.sort.reverse : paths.sort
-end
-
-main
+puts LS.new().generate_content

--- a/07.ls_object/ls.rb
+++ b/07.ls_object/ls.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'optparse'
+
+def main
+  opt_params = ARGV.getopts('arl')
+  targets = ARGV.empty? ? [Dir.pwd] : ARGV.sort
+  existent_targets, noexistent_targets = targets.partition { |target| File.exist?(target) }
+  directories, files = existent_targets.partition { |target| File.ftype(target) == 'directory' }
+
+  # TODO
+  # 各Pathクラスから文字列作成(形式はFormatterクラスの責務とする)
+  # 取得した文字列を標準出力へ表示
+  #  -> 表示する順番については、こちらの責務
+  #  -> 引数を複数指定した場合のディレクトリ名表示もこちらの責務とする
+  #     (表示する対象が複数あることを、Formatterは知らない)
+end
+
+main

--- a/07.ls_object/ls.rb
+++ b/07.ls_object/ls.rb
@@ -1,20 +1,40 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'optparse'
+require_relative 'optional_parameter'
+require_relative 'non_existent_container'
+require_relative 'unrelated_file_container'
+require_relative 'directory'
 
 def main
-  opt_params = ARGV.getopts('arl')
-  targets = ARGV.empty? ? [Dir.pwd] : ARGV.sort
-  existent_targets, noexistent_targets = targets.partition { |target| File.exist?(target) }
-  directories, files = existent_targets.partition { |target| File.ftype(target) == 'directory' }
+  opt_param = OptionalParameter.new
 
-  # TODO
-  # 各Pathクラスから文字列作成(形式はFormatterクラスの責務とする)
-  # 取得した文字列を標準出力へ表示
-  #  -> 表示する順番については、こちらの責務
-  #  -> 引数を複数指定した場合のディレクトリ名表示もこちらの責務とする
-  #     (表示する対象が複数あることを、Formatterは知らない)
+  paths = ARGV.empty? ? [Dir.pwd] : ARGV.sort
+  existent_paths, nonexistent_paths = paths.partition { |path| File.exist?(path) }
+  directory_paths, file_paths = existent_paths.partition { |path| File.ftype(path) == 'directory' }
+
+  sorted_file_paths = sort_with_reverse_option(file_paths, opt_param.sort_reverse?)
+  sorted_directory_paths = sort_with_reverse_option(directory_paths, opt_param.sort_reverse?)
+
+  containers = []
+  containers << NonExistentContainer.new(nonexistent_paths) if nonexistent_paths.any?
+  containers << UnrelatedFileContainer.new(sorted_file_paths) if sorted_file_paths.any?
+  sorted_directory_paths.each do |directory_path|
+    containers << Directory.new(directory_path)
+  end
+
+  result =
+    containers.each_with_object([]).with_index do |(container, result), index|
+      result << "#{container.path}:" if container.instance_of?(Directory)
+      result << container.generate_list_content(opt_param)
+      result << "\n" if !container.instance_of?(NonExistentContainer) && index != containers.size - 1
+    end
+
+  puts result
+end
+
+def sort_with_reverse_option(items, reverse)
+  reverse ? items.sort.reverse : items.sort
 end
 
 main

--- a/07.ls_object/ls.rb
+++ b/07.ls_object/ls.rb
@@ -36,8 +36,8 @@ class LS
     sorted_directory_paths = sort_with_reverse_option(directory_paths, opt_param.sort_reverse?)
 
     containers = []
-    containers << NonExistentContainer.new(nonexistent_paths) if nonexistent_paths.any?
-    containers << UnrelatedFileContainer.new(sorted_file_paths) if sorted_file_paths.any?
+    containers << NonExistentContainer.new(nonexistent_paths) unless nonexistent_paths.empty?
+    containers << UnrelatedFileContainer.new(sorted_file_paths) unless sorted_file_paths.empty?
     sorted_directory_paths.each_with_object(containers) do |directory_path, result|
       result << Directory.new(directory_path)
     end

--- a/07.ls_object/ls.rb
+++ b/07.ls_object/ls.rb
@@ -5,6 +5,7 @@ require_relative 'optional_parameter'
 require_relative 'non_existent_container'
 require_relative 'unrelated_file_container'
 require_relative 'directory'
+require_relative 'formatter_factory'
 
 def main
   opt_param = OptionalParameter.new
@@ -25,16 +26,17 @@ def main
 
   result =
     containers.each_with_object([]).with_index do |(container, result), index|
+      container.generate_entries(opt_param)
       result << "#{container.path}:" if container.instance_of?(Directory)
-      result << container.generate_list_content(opt_param)
+      result << FormatterFactory.create(container, opt_param).generate_formatted_content
       result << "\n" if !container.instance_of?(NonExistentContainer) && index != containers.size - 1
     end
 
   puts result
 end
 
-def sort_with_reverse_option(items, reverse)
-  reverse ? items.sort.reverse : items.sort
+def sort_with_reverse_option(paths, reverse)
+  reverse ? paths.sort.reverse : paths.sort
 end
 
 main

--- a/07.ls_object/ls.rb
+++ b/07.ls_object/ls.rb
@@ -8,9 +8,9 @@ require_relative 'directory'
 require_relative 'formatter_factory'
 
 class LS
-  def initialize
-    @opt_param = OptionalParameter.new
-    @paths = ARGV.empty? ? [Dir.pwd] : ARGV.sort
+  def initialize(opt_param, paths)
+    @opt_param = opt_param
+    @paths = paths
   end
 
   def generate_content
@@ -48,4 +48,8 @@ class LS
   end
 end
 
-puts LS.new.generate_content
+if __FILE__ == $PROGRAM_NAME
+  opt_param = OptionalParameter.new
+  paths = ARGV.empty? ? [Dir.pwd] : ARGV
+  puts LS.new(opt_param, paths).generate_content
+end

--- a/07.ls_object/ls.rb
+++ b/07.ls_object/ls.rb
@@ -15,23 +15,19 @@ class LS
 
   def generate_content
     containers = generate_containers
-    containers.each_with_object([]) do |container, result|
+    containers.map do |container|
       container.generate_entries(opt_param)
-      content = []
-      content << "#{container.path}:\n" if container.instance_of?(Directory) && containers.size > 1
-      content << FormatterFactory.create(container, opt_param).generate_formatted_content
-      content << "\n" unless container.instance_of?(NonExistentContainer)
-      result << content.join
+      subset_content = []
+      subset_content << "#{container.path}:\n" if container.instance_of?(Directory) && containers.size > 1
+      subset_content << FormatterFactory.create(container, opt_param).generate_formatted_content
+      subset_content << "\n" unless container.instance_of?(NonExistentContainer)
+      subset_content.join
     end.join("\n")
   end
 
   private
 
   attr_reader :opt_param, :paths
-
-  def sort_with_reverse_option(paths, reverse)
-    reverse ? paths.sort.reverse : paths.sort
-  end
 
   def generate_containers
     existent_paths, nonexistent_paths = paths.partition { |path| File.exist?(path) }
@@ -45,6 +41,10 @@ class LS
     sorted_directory_paths.each_with_object(containers) do |directory_path, result|
       result << Directory.new(directory_path)
     end
+  end
+
+  def sort_with_reverse_option(paths, reverse)
+    reverse ? paths.sort.reverse : paths.sort
   end
 end
 

--- a/07.ls_object/ls.rb
+++ b/07.ls_object/ls.rb
@@ -14,10 +14,14 @@ class LS
   end
 
   def generate_content
-    generate_containers.each_with_object([]) do |container, result|
+    containers = generate_containers
+    containers.each_with_object([]) do |container, result|
       container.generate_entries(opt_param)
-      result << "\n#{container.path}:" if container.instance_of?(Directory)
-      result << FormatterFactory.create(container, opt_param).generate_formatted_content
+      content = []
+      content << "#{container.path}:\n" if container.instance_of?(Directory) && containers.size > 1
+      content << FormatterFactory.create(container, opt_param).generate_formatted_content
+      content << "\n" unless container.instance_of?(NonExistentContainer)
+      result << content.join
     end.join("\n")
   end
 

--- a/07.ls_object/ls.rb
+++ b/07.ls_object/ls.rb
@@ -44,4 +44,4 @@ class LS
   end
 end
 
-puts LS.new().generate_content
+puts LS.new.generate_content

--- a/07.ls_object/macxattr.c
+++ b/07.ls_object/macxattr.c
@@ -1,0 +1,41 @@
+/* macxattr.c */
+#include <sys/types.h>
+#include <sys/xattr.h>
+#include <sys/types.h>
+#include <sys/acl.h>
+#include <stdio.h>
+#include <ruby.h>
+
+VALUE macxattr;
+
+VALUE get_macxattr_func(VALUE self, VALUE path)
+{
+  char* pPath = StringValuePtr(path);
+  acl_t acl = NULL;
+  acl_entry_t dummy;
+  ssize_t xattr = 0;
+
+  acl = acl_get_link_np(pPath, ACL_TYPE_EXTENDED);
+  if (acl && acl_get_entry(acl, ACL_FIRST_ENTRY, &dummy) == -1) {
+      acl_free(acl);
+      acl = NULL;
+  }
+  xattr = listxattr(pPath, NULL, 0, XATTR_NOFOLLOW);
+  if (xattr < 0)
+      xattr = 0;
+
+  if (xattr > 0){
+      return rb_str_new2("@");
+  } else if (acl != NULL){
+      return rb_str_new2("+");
+  } else {
+      return rb_str_new2(" ");
+  }
+}
+
+void Init_macxattr()
+{
+  macxattr = rb_define_class("MacXattr", rb_cObject);
+
+  rb_define_method(macxattr, "get_macxattr", RUBY_METHOD_FUNC(get_macxattr_func), 1);
+}

--- a/07.ls_object/non_existent_container.rb
+++ b/07.ls_object/non_existent_container.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative 'entry'
-require_relative 'formatter_factory'
 
 class NonExistentContainer
   attr_reader :entries
@@ -10,8 +9,7 @@ class NonExistentContainer
     @paths = non_existent_paths
   end
 
-  def generate_list_content(opt_param)
+  def generate_entries(_opt_param)
     @entries = @paths.map { |path| Entry.new(path) }
-    FormatterFactory.create(self, opt_param).generate_formatted_content
   end
 end

--- a/07.ls_object/non_existent_container.rb
+++ b/07.ls_object/non_existent_container.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class NonExistentContainer
+  def initialize(non_existent_paths)
+    @paths = non_existent_paths
+  end
+
+  def generate_list_content(opt_param)
+  end
+end

--- a/07.ls_object/non_existent_container.rb
+++ b/07.ls_object/non_existent_container.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
 require_relative 'entry'
+require_relative 'formatter_factory'
 
 class NonExistentContainer
+  attr_reader :entries
+
   def initialize(non_existent_paths)
     @paths = non_existent_paths
   end
 
   def generate_list_content(opt_param)
     @entries = @paths.map { |path| Entry.new(path) }
+    FormatterFactory.create(opt_param, non_existent: true).generate_formatted_content(self, opt_param)
   end
 end

--- a/07.ls_object/non_existent_container.rb
+++ b/07.ls_object/non_existent_container.rb
@@ -10,6 +10,6 @@ class NonExistentContainer
   end
 
   def generate_entries(_opt_param)
-    @entries = @paths.map { |path| Entry.new(path) }
+    @entries = @paths.sort.map { |path| Entry.new(path) }
   end
 end

--- a/07.ls_object/non_existent_container.rb
+++ b/07.ls_object/non_existent_container.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
+require_relative 'entry'
+
 class NonExistentContainer
   def initialize(non_existent_paths)
     @paths = non_existent_paths
   end
 
   def generate_list_content(opt_param)
+    @entries = @paths.map { |path| Entry.new(path) }
   end
 end

--- a/07.ls_object/non_existent_container.rb
+++ b/07.ls_object/non_existent_container.rb
@@ -12,6 +12,6 @@ class NonExistentContainer
 
   def generate_list_content(opt_param)
     @entries = @paths.map { |path| Entry.new(path) }
-    FormatterFactory.create(opt_param, non_existent: true).generate_formatted_content(self, opt_param)
+    FormatterFactory.create(self, opt_param).generate_formatted_content
   end
 end

--- a/07.ls_object/non_existent_formatter.rb
+++ b/07.ls_object/non_existent_formatter.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class NonExistentFormatter
+end

--- a/07.ls_object/non_existent_formatter.rb
+++ b/07.ls_object/non_existent_formatter.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
 class NonExistentFormatter
+  def generate_formatted_content(container, opt_param)
+    container.entries.map do |entry|
+      "ls: #{entry.path}: No such file or direcotry"
+    end.join("\n")
+  end
 end

--- a/07.ls_object/non_existent_formatter.rb
+++ b/07.ls_object/non_existent_formatter.rb
@@ -8,6 +8,6 @@ class NonExistentFormatter
   def generate_formatted_content
     @entries.map do |entry|
       "ls: #{entry.path}: No such file or directory"
-    end.sort.join("\n")
+    end.join("\n")
   end
 end

--- a/07.ls_object/non_existent_formatter.rb
+++ b/07.ls_object/non_existent_formatter.rb
@@ -7,7 +7,7 @@ class NonExistentFormatter
 
   def generate_formatted_content
     @entries.map do |entry|
-      "ls: #{entry.path}: No such file or direcotry"
-    end.join("\n")
+      "ls: #{entry.path}: No such file or directory"
+    end.sort.join("\n")
   end
 end

--- a/07.ls_object/non_existent_formatter.rb
+++ b/07.ls_object/non_existent_formatter.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 class NonExistentFormatter
-  def generate_formatted_content(container, opt_param)
-    container.entries.map do |entry|
+  def initialize(entries)
+    @entries = entries
+  end
+
+  def generate_formatted_content
+    @entries.map do |entry|
       "ls: #{entry.path}: No such file or direcotry"
     end.join("\n")
   end

--- a/07.ls_object/optional_parameter.rb
+++ b/07.ls_object/optional_parameter.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'optparse'
+
+class OptionalParameter
+  def initialize
+    optional_args = ARGV.getopts('arl')
+    @show_all = optional_args['a']
+    @sort_reverse = optional_args['r']
+    @long_format = optional_args['l']
+  end
+
+  def show_all? = @show_all
+
+  def sort_reverse? = @sort_reverse
+
+  def long_format? = @long_format
+end

--- a/07.ls_object/optional_parameter.rb
+++ b/07.ls_object/optional_parameter.rb
@@ -5,14 +5,14 @@ require 'optparse'
 class OptionalParameter
   def initialize
     optional_args = ARGV.getopts('arl')
-    @show_all = optional_args['a']
-    @sort_reverse = optional_args['r']
-    @long_format = optional_args['l']
+    @opt_a = optional_args['a']
+    @opt_r = optional_args['r']
+    @opt_l = optional_args['l']
   end
 
-  def show_all? = @show_all
+  def show_all? = @opt_a
 
-  def sort_reverse? = @sort_reverse
+  def sort_reverse? = @opt_r
 
-  def long_format? = @long_format
+  def long_format? = @opt_l
 end

--- a/07.ls_object/short_formatter.rb
+++ b/07.ls_object/short_formatter.rb
@@ -4,37 +4,39 @@ class ShortFormatter
   MAX_NUM_OF_COLUMNS = 3
 
   def initialize(entries)
-    @entries = entries
+    @entry_names = entries.map(&:display_name)
   end
 
   def generate_formatted_content
-    display_names = entries.map(&:display_name)
-
-    max_bytes_of_name = display_names.max_by(&:bytesize).bytesize
-    terminal_width = current_terminal_width
-    num_of_columns = MAX_NUM_OF_COLUMNS.downto(1).find { |n| max_bytes_of_name * n + (n - 1) <= terminal_width }
-    num_of_rows = (display_names.size / num_of_columns.to_f).ceil
-
-    matrix = display_names.each_slice(num_of_rows).to_a
-
-    # transposeするために、要素数を合わせる
-    (num_of_rows - matrix.last.size).times { matrix.last << nil }
-
-    matrix.transpose.map do |subset_names|
+    max_name_width = entry_names.max_by(&:bytesize).bytesize
+    num_of_rows = calc_num_of_rows(max_name_width)
+    generate_rectangular_array(num_of_rows).map do |subset_names|
       subset_names.map do |name|
-        ljust_for_mbchar(name, max_bytes_of_name) unless name.nil?
+        ljust_for_mbchar(name, max_name_width) unless name.nil?
       end.join(' ').rstrip
     end.join("\n")
   end
 
   private
 
-  attr_reader :entries
+  attr_reader :entry_names
+
+  def generate_rectangular_array(num_of_rows)
+    rectangular_array = entry_names.each_slice(num_of_rows).to_a
+    rectangular_array[-1] += Array.new(num_of_rows - rectangular_array.last.size) # 内側の配列の要素数を合わせる
+    rectangular_array.transpose
+  end
+
+  def calc_num_of_rows(max_name_width)
+    terminal_width = current_terminal_width
+    num_of_columns = MAX_NUM_OF_COLUMNS.downto(1).find { |n| max_name_width * n + (n - 1) <= terminal_width }
+    (entry_names.size / num_of_columns.to_f).ceil
+  end
 
   # 半角英数字以外のファイル名でも表示が崩れないための対応
-  def ljust_for_mbchar(str, width)
-    num_of_mbchar = str.split('').count { |char| char.match?(/[^ -~｡-ﾟ]/) }
-    str.ljust(width - num_of_mbchar)
+  def ljust_for_mbchar(name, width)
+    num_of_mbchar = name.split('').count { |char| char.match?(/[^ -~｡-ﾟ]/) }
+    name.ljust(width - num_of_mbchar)
   end
 
   def current_terminal_width

--- a/07.ls_object/short_formatter.rb
+++ b/07.ls_object/short_formatter.rb
@@ -3,8 +3,12 @@
 class ShortFormatter
   MAX_COLUMNS = 3
 
-  def generate_formatted_content(container, opt_param)
-    display_names = generate_diplay_names(container, opt_param)
+  def initialize(entries)
+    @entries = entries
+  end
+
+  def generate_formatted_content
+    display_names = entries.map(&:display_name)
 
     max_bytes_of_name = display_names.max_by(&:bytesize).bytesize
     terminal_width = `tput cols`.to_i
@@ -25,17 +29,7 @@ class ShortFormatter
 
   private
 
-  def generate_diplay_names(container, opt_param)
-    display_names = container.entries.map(&:display_name)
-    filtered_names =
-      if opt_param.show_all?
-        display_names
-      else
-        display_names.reject { |name| name[0] == '.' }
-      end
-
-    opt_param.sort_reverse? ? filtered_names.sort.reverse : filtered_names.sort
-  end
+  attr_reader :entries
 
   # 半角英数字以外のファイル名でも表示が崩れないための対応
   def ljust_for_mbchar(str, width)

--- a/07.ls_object/short_formatter.rb
+++ b/07.ls_object/short_formatter.rb
@@ -11,7 +11,7 @@ class ShortFormatter
     display_names = entries.map(&:display_name)
 
     max_bytes_of_name = display_names.max_by(&:bytesize).bytesize
-    terminal_width = `tput cols`.to_i
+    terminal_width = current_terminal_width
     num_of_columns = MAX_NUM_OF_COLUMNS.downto(1).find { |n| max_bytes_of_name * n + (n - 1) <= terminal_width }
     num_of_rows = (display_names.size / num_of_columns.to_f).ceil
 
@@ -35,5 +35,19 @@ class ShortFormatter
   def ljust_for_mbchar(str, width)
     num_of_mbchar = str.split('').count { |char| char.match?(/[^ -~｡-ﾟ]/) }
     str.ljust(width - num_of_mbchar)
+  end
+
+  def current_terminal_width
+    if @terminal_width_for_test
+      # 自動テスト用の分岐 : set_terminal_widhで幅を設定後、1度だけ設定した幅を使用する
+      @terminal_width_for_test.tap { @terminal_width_for_test = nil }
+    else
+      `tput cols`.to_i
+    end
+  end
+
+  # 自動テスト用メソッド（ターミナルの幅を仮設定する）
+  def terminal_width_for_test(width)
+    @terminal_width_for_test = width
   end
 end

--- a/07.ls_object/short_formatter.rb
+++ b/07.ls_object/short_formatter.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ShortFormatter
+  def initialize(opt_param)
+    @opt_param = opt_param
+  end
+end

--- a/07.ls_object/short_formatter.rb
+++ b/07.ls_object/short_formatter.rb
@@ -8,7 +8,7 @@ class ShortFormatter
   end
 
   def generate_formatted_content
-    max_name_width = entry_names.max_by(&:bytesize).bytesize
+    max_name_width = @entry_names.max_by(&:bytesize).bytesize
     num_of_rows = calc_num_of_rows(max_name_width)
     generate_rectangular_array(num_of_rows).map do |subset_names|
       subset_names.map do |name|
@@ -19,10 +19,8 @@ class ShortFormatter
 
   private
 
-  attr_reader :entry_names
-
   def generate_rectangular_array(num_of_rows)
-    rectangular_array = entry_names.each_slice(num_of_rows).to_a
+    rectangular_array = @entry_names.each_slice(num_of_rows).to_a
     rectangular_array[-1] += Array.new(num_of_rows - rectangular_array.last.size) # 内側の配列の要素数を合わせる
     rectangular_array.transpose
   end
@@ -30,7 +28,7 @@ class ShortFormatter
   def calc_num_of_rows(max_name_width)
     terminal_width = current_terminal_width
     num_of_columns = MAX_NUM_OF_COLUMNS.downto(1).find { |n| max_name_width * n + (n - 1) <= terminal_width }
-    (entry_names.size / num_of_columns.to_f).ceil
+    (@entry_names.size / num_of_columns.to_f).ceil
   end
 
   # 半角英数字以外のファイル名でも表示が崩れないための対応

--- a/07.ls_object/short_formatter.rb
+++ b/07.ls_object/short_formatter.rb
@@ -23,7 +23,7 @@ class ShortFormatter
     matrix.transpose.map do |subset_names|
       subset_names.map do |name|
         ljust_for_mbchar(name, max_bytes_of_name) unless name.nil?
-      end.join(' ')
+      end.join(' ').rstrip
     end.join("\n")
   end
 

--- a/07.ls_object/short_formatter.rb
+++ b/07.ls_object/short_formatter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ShortFormatter
-  MAX_COLUMNS = 3
+  MAX_NUM_OF_COLUMNS = 3
 
   def initialize(entries)
     @entries = entries
@@ -12,7 +12,7 @@ class ShortFormatter
 
     max_bytes_of_name = display_names.max_by(&:bytesize).bytesize
     terminal_width = `tput cols`.to_i
-    num_of_columns = MAX_COLUMNS.downto(1).find { |n| max_bytes_of_name * n + (n - 1) <= terminal_width }
+    num_of_columns = MAX_NUM_OF_COLUMNS.downto(1).find { |n| max_bytes_of_name * n + (n - 1) <= terminal_width }
     num_of_rows = (display_names.size / num_of_columns.to_f).ceil
 
     matrix = display_names.each_slice(num_of_rows).to_a

--- a/07.ls_object/short_formatter.rb
+++ b/07.ls_object/short_formatter.rb
@@ -1,7 +1,45 @@
 # frozen_string_literal: true
 
 class ShortFormatter
-  def initialize(opt_param)
-    @opt_param = opt_param
+  MAX_COLUMNS = 3
+
+  def generate_formatted_content(container, opt_param)
+    display_names = generate_diplay_names(container, opt_param)
+
+    max_bytes_of_name = display_names.max_by(&:bytesize).bytesize
+    terminal_width = `tput cols`.to_i
+    num_of_columns = MAX_COLUMNS.downto(1).find { |n| max_bytes_of_name * n + (n - 1) <= terminal_width }
+    num_of_rows = (display_names.size / num_of_columns.to_f).ceil
+
+    matrix = display_names.each_slice(num_of_rows).to_a
+
+    # transposeするために、要素数を合わせる
+    (num_of_rows - matrix.last.size).times { matrix.last << nil }
+
+    matrix.transpose.map do |subset_names|
+      subset_names.map do |name|
+        ljust_for_mbchar(name, max_bytes_of_name) unless name.nil?
+      end.join(' ')
+    end.join("\n")
+  end
+
+  private
+
+  def generate_diplay_names(container, opt_param)
+    display_names = container.entries.map(&:display_name)
+    filtered_names =
+      if opt_param.show_all?
+        display_names
+      else
+        display_names.reject { |name| name[0] == '.' }
+      end
+
+    opt_param.sort_reverse? ? filtered_names.sort.reverse : filtered_names.sort
+  end
+
+  # 半角英数字以外のファイル名でも表示が崩れないための対応
+  def ljust_for_mbchar(str, width)
+    num_of_mbchar = str.split('').count { |char| char.match?(/[^ -~｡-ﾟ]/) }
+    str.ljust(width - num_of_mbchar)
   end
 end

--- a/07.ls_object/statistics.rb
+++ b/07.ls_object/statistics.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Statistics
+  Statistics = Struct.new(
+    :total_block_size,
+    :nlink_length,
+    :owner_name_length,
+    :group_name_length,
+    :file_size_length
+  )
+
+  def generate_statistics
+    Statistics.new(
+      total_block_size: entries.sum(&:blocks),
+      nlink_length: entries.map(&:nlink).max.to_s.length,
+      owner_name_length: entries.map(&:owner_name).max_by(&:length).length,
+      group_name_length: entries.map(&:group_name).max_by(&:length).length,
+      file_size_length: entries.map(&:file_size).max.to_s.length
+    )
+  end
+end

--- a/07.ls_object/test/common/test_common.rb
+++ b/07.ls_object/test/common/test_common.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module TestCommon
+  NON_EXISTENT_FILES = %w[
+    ./non_existent_file_1
+    ./non_existent_file_2
+    ./non_existent_file_3
+    ./non_existent_file_4
+    ../non_existent_file_101.a
+    ../non_existent_file_102.g
+    ../non_existent_file_103.m
+    ../non_existent_file_104.z
+  ].freeze
+
+  EXISTENT_FILES = %w[
+    ./directory.rb
+    ./file_permission.rb
+    ./non_existent_container.rb
+    ./short_formatter.rb
+    ./statistics.rb
+    ./file_type.rb
+    long_formatter.rb
+    ls.rb
+    non_existent_formatter.rb
+    formatter_factory.rb
+    entry.rb
+    unrelated_file_container.rb
+    optional_parameter.rb
+  ].freeze
+
+  DIRECTORIES = %w[
+    ./
+    ../
+  ].freeze
+end

--- a/07.ls_object/test/common/test_double_optional_parameter.rb
+++ b/07.ls_object/test/common/test_double_optional_parameter.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class TestDoubleOptionalParameter
+  def initialize(opt_a:, opt_r:, opt_l:)
+    @opt_a = opt_a
+    @opt_r = opt_r
+    @opt_l = opt_l
+  end
+
+  def show_all? = @opt_a
+  def sort_reverse? = @opt_r
+  def long_format? = @opt_l
+end

--- a/07.ls_object/test/test_long_formatter.rb
+++ b/07.ls_object/test/test_long_formatter.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'test/unit'
+require_relative 'common/test_common'
+require_relative 'common/test_double_optional_parameter'
+require_relative '../ls'
+
+class TestLongFormatter < Test::Unit::TestCase
+  include TestCommon
+
+  test 'オプション指定（l）、パス指定（ファイル）' do
+    path_args = EXISTENT_FILES
+    expected = `ls -l #{path_args.join(' ')}`.chomp
+
+    opt_param = TestDoubleOptionalParameter.new(opt_a: false, opt_r: false, opt_l: true)
+    container = UnrelatedFileContainer.new(path_args)
+    container.generate_entries(opt_param)
+    long_formatter = FormatterFactory.create(container, opt_param)
+
+    assert_equal(expected, long_formatter.generate_formatted_content)
+  end
+
+  test 'オプション指定（a,l）、パス指定（ファイル）' do
+    path_args = EXISTENT_FILES
+    expected = `ls -al #{path_args.join(' ')}`.chomp
+
+    opt_param = TestDoubleOptionalParameter.new(opt_a: true, opt_r: false, opt_l: true)
+    container = UnrelatedFileContainer.new(path_args)
+    container.generate_entries(opt_param)
+    long_formatter = FormatterFactory.create(container, opt_param)
+
+    assert_equal(expected, long_formatter.generate_formatted_content)
+  end
+
+  test 'オプション指定（r,l）、パス指定（ファイル）' do
+    path_args = EXISTENT_FILES
+    expected = `ls -rl #{path_args.join(' ')}`.chomp
+
+    opt_param = TestDoubleOptionalParameter.new(opt_a: false, opt_r: true, opt_l: true)
+    container = UnrelatedFileContainer.new(path_args)
+    container.generate_entries(opt_param)
+    long_formatter = FormatterFactory.create(container, opt_param)
+
+    assert_equal(expected, long_formatter.generate_formatted_content)
+  end
+
+  test 'オプション指定（a,r,l）、パス指定（ファイル）' do
+    path_args = EXISTENT_FILES
+    expected = `ls -arl #{path_args.join(' ')}`.chomp
+
+    opt_param = TestDoubleOptionalParameter.new(opt_a: true, opt_r: true, opt_l: true)
+    container = UnrelatedFileContainer.new(path_args)
+    container.generate_entries(opt_param)
+    long_formatter = FormatterFactory.create(container, opt_param)
+
+    assert_equal(expected, long_formatter.generate_formatted_content)
+  end
+
+  test 'オプション指定（l）、パス指定（ディレクトリ）' do
+    dir_path = './'
+    expected = `ls -l #{dir_path}`.chomp
+
+    opt_param = TestDoubleOptionalParameter.new(opt_a: false, opt_r: false, opt_l: true)
+    container = Directory.new(dir_path)
+    container.generate_entries(opt_param)
+    long_formatter = FormatterFactory.create(container, opt_param)
+
+    assert_equal(expected, long_formatter.generate_formatted_content)
+  end
+
+  test 'オプション指定（a,l）、パス指定（ディレクトリ）' do
+    dir_path = './'
+    expected = `ls -al #{dir_path}`.chomp
+
+    opt_param = TestDoubleOptionalParameter.new(opt_a: true, opt_r: false, opt_l: true)
+    container = Directory.new(dir_path)
+    container.generate_entries(opt_param)
+    long_formatter = FormatterFactory.create(container, opt_param)
+
+    assert_equal(expected, long_formatter.generate_formatted_content)
+  end
+
+  test 'オプション指定（r,l）、パス指定（ディレクトリ）' do
+    dir_path = './'
+    expected = `ls -rl #{dir_path}`.chomp
+
+    opt_param = TestDoubleOptionalParameter.new(opt_a: false, opt_r: true, opt_l: true)
+    container = Directory.new(dir_path)
+    container.generate_entries(opt_param)
+    long_formatter = FormatterFactory.create(container, opt_param)
+
+    assert_equal(expected, long_formatter.generate_formatted_content)
+  end
+
+  test 'オプション指定（a,r,l）、パス指定（ディレクトリ）' do
+    dir_path = './'
+    expected = `ls -arl #{dir_path}`.chomp
+
+    opt_param = TestDoubleOptionalParameter.new(opt_a: true, opt_r: true, opt_l: true)
+    container = Directory.new(dir_path)
+    container.generate_entries(opt_param)
+    long_formatter = FormatterFactory.create(container, opt_param)
+
+    assert_equal(expected, long_formatter.generate_formatted_content)
+  end
+end

--- a/07.ls_object/test/test_ls.rb
+++ b/07.ls_object/test/test_ls.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'test/unit'
+require_relative 'common/test_common'
+require_relative 'common/test_double_optional_parameter'
+require_relative '../ls'
+
+class TestLS < Test::Unit::TestCase
+  include TestCommon
+
+  test 'オプション指定（a, r, l）、パス指定（存在するファイル、ディレクトリ）' do
+    args = [*EXISTENT_FILES, *DIRECTORIES]
+    expected = `ls -arl #{args.join(' ')}`
+
+    opt_param = TestDoubleOptionalParameter.new(opt_a: true, opt_r: true, opt_l: true)
+    ls = LS.new(opt_param, args)
+
+    assert_equal(expected, ls.generate_content)
+  end
+
+  test 'オプション指定（a, l）、指定（存在するディレクトリ）' do
+    args = DIRECTORIES
+    expected = `ls -al #{args.join(' ')}`
+
+    opt_param = TestDoubleOptionalParameter.new(opt_a: true, opt_r: false, opt_l: true)
+    ls = LS.new(opt_param, args)
+
+    assert_equal(expected, ls.generate_content)
+  end
+
+  test 'オプション指定（r, l）、指定（存在するファイル）' do
+    args = EXISTENT_FILES
+    expected = `ls -rl #{args.join(' ')}`
+
+    opt_param = TestDoubleOptionalParameter.new(opt_a: false, opt_r: true, opt_l: true)
+    ls = LS.new(opt_param, args)
+
+    assert_equal(expected, ls.generate_content)
+  end
+
+  test 'オプション指定（l）、指定（なし）' do
+    expected = `ls -l`
+
+    opt_param = TestDoubleOptionalParameter.new(opt_a: false, opt_r: false, opt_l: true)
+    ls = LS.new(opt_param, [Dir.pwd])
+
+    assert_equal(expected, ls.generate_content)
+  end
+end

--- a/07.ls_object/test/test_non_existent_formatter.rb
+++ b/07.ls_object/test/test_non_existent_formatter.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'test/unit'
+require_relative 'common/test_common'
+require_relative 'common/test_double_optional_parameter'
+require_relative '../ls'
+
+class TestLongFormatter < Test::Unit::TestCase
+  include TestCommon
+
+  test 'オプション指定（なし）' do
+    path_args = NON_EXISTENT_FILES
+    expected = <<~TEXT.chomp
+      ls: ../non_existent_file_101.a: No such file or directory
+      ls: ../non_existent_file_102.g: No such file or directory
+      ls: ../non_existent_file_103.m: No such file or directory
+      ls: ../non_existent_file_104.z: No such file or directory
+      ls: ./non_existent_file_1: No such file or directory
+      ls: ./non_existent_file_2: No such file or directory
+      ls: ./non_existent_file_3: No such file or directory
+      ls: ./non_existent_file_4: No such file or directory
+    TEXT
+
+    opt_param = TestDoubleOptionalParameter.new(opt_a: false, opt_r: false, opt_l: false)
+    container = NonExistentContainer.new(path_args)
+    container.generate_entries(opt_param)
+    non_existent_formatter = FormatterFactory.create(container, opt_param)
+
+    assert_equal(expected, non_existent_formatter.generate_formatted_content)
+  end
+
+  test 'オプション指定（a, r）' do
+    path_args = NON_EXISTENT_FILES
+    expected = <<~TEXT.chomp
+      ls: ../non_existent_file_101.a: No such file or directory
+      ls: ../non_existent_file_102.g: No such file or directory
+      ls: ../non_existent_file_103.m: No such file or directory
+      ls: ../non_existent_file_104.z: No such file or directory
+      ls: ./non_existent_file_1: No such file or directory
+      ls: ./non_existent_file_2: No such file or directory
+      ls: ./non_existent_file_3: No such file or directory
+      ls: ./non_existent_file_4: No such file or directory
+    TEXT
+
+    opt_param = TestDoubleOptionalParameter.new(opt_a: true, opt_r: true, opt_l: false)
+    container = NonExistentContainer.new(path_args)
+    container.generate_entries(opt_param)
+    non_existent_formatter = FormatterFactory.create(container, opt_param)
+
+    assert_equal(expected, non_existent_formatter.generate_formatted_content)
+  end
+end

--- a/07.ls_object/test/test_short_formatter.rb
+++ b/07.ls_object/test/test_short_formatter.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+require 'test/unit'
+require_relative 'common/test_common'
+require_relative 'common/test_double_optional_parameter'
+require_relative '../ls'
+
+class TestShortFormatter < Test::Unit::TestCase
+  include TestCommon
+
+  test 'オプション指定（なし）、パス指定（ファイル）、列数（1）' do
+    expected = <<~TEXT.chomp
+      ./directory.rb
+      ./file_permission.rb
+      ./file_type.rb
+      ./non_existent_container.rb
+      ./short_formatter.rb
+      ./statistics.rb
+      entry.rb
+      formatter_factory.rb
+      long_formatter.rb
+      ls.rb
+      non_existent_formatter.rb
+      optional_parameter.rb
+      unrelated_file_container.rb
+    TEXT
+
+    opt_param = TestDoubleOptionalParameter.new(opt_a: false, opt_r: false, opt_l: false)
+    container = UnrelatedFileContainer.new(EXISTENT_FILES)
+    container.generate_entries(opt_param)
+    short_formatter = FormatterFactory.create(container, opt_param)
+    short_formatter.send(:terminal_width_for_test, 40)
+
+    assert_equal(expected, short_formatter.generate_formatted_content)
+  end
+
+  test 'オプション指定（a）、パス指定（ファイル）、列数（1）' do
+    expected = <<~TEXT.chomp
+      ./directory.rb
+      ./file_permission.rb
+      ./file_type.rb
+      ./non_existent_container.rb
+      ./short_formatter.rb
+      ./statistics.rb
+      entry.rb
+      formatter_factory.rb
+      long_formatter.rb
+      ls.rb
+      non_existent_formatter.rb
+      optional_parameter.rb
+      unrelated_file_container.rb
+    TEXT
+
+    opt_param = TestDoubleOptionalParameter.new(opt_a: true, opt_r: false, opt_l: false)
+    container = UnrelatedFileContainer.new(EXISTENT_FILES)
+    container.generate_entries(opt_param)
+    short_formatter = FormatterFactory.create(container, opt_param)
+    short_formatter.send(:terminal_width_for_test, 40)
+
+    assert_equal(expected, short_formatter.generate_formatted_content)
+  end
+
+  test 'オプション指定（r）、パス指定（ファイル）、列数（2）' do
+    expected = <<~TEXT.chomp
+      unrelated_file_container.rb ./statistics.rb
+      optional_parameter.rb       ./short_formatter.rb
+      non_existent_formatter.rb   ./non_existent_container.rb
+      ls.rb                       ./file_type.rb
+      long_formatter.rb           ./file_permission.rb
+      formatter_factory.rb        ./directory.rb
+      entry.rb
+    TEXT
+
+    opt_param = TestDoubleOptionalParameter.new(opt_a: false, opt_r: true, opt_l: false)
+    container = UnrelatedFileContainer.new(EXISTENT_FILES)
+    container.generate_entries(opt_param)
+    short_formatter = FormatterFactory.create(container, opt_param)
+    short_formatter.send(:terminal_width_for_test, 70)
+
+    assert_equal(expected, short_formatter.generate_formatted_content)
+  end
+
+  test 'オプション指定（a, r）、パス指定（ファイル）、列数（3）' do
+    expected = <<~TEXT.chomp
+      unrelated_file_container.rb formatter_factory.rb        ./file_type.rb
+      optional_parameter.rb       entry.rb                    ./file_permission.rb
+      non_existent_formatter.rb   ./statistics.rb             ./directory.rb
+      ls.rb                       ./short_formatter.rb
+      long_formatter.rb           ./non_existent_container.rb
+    TEXT
+
+    opt_param = TestDoubleOptionalParameter.new(opt_a: true, opt_r: true, opt_l: false)
+    container = UnrelatedFileContainer.new(EXISTENT_FILES)
+    container.generate_entries(opt_param)
+    short_formatter = FormatterFactory.create(container, opt_param)
+    short_formatter.send(:terminal_width_for_test, 120)
+
+    assert_equal(expected, short_formatter.generate_formatted_content)
+  end
+
+  test 'オプション指定（なし）、パス指定（ディレクトリ）、列数（1）' do
+    expected = <<~TEXT.chomp
+      Gemfile
+      Gemfile.lock
+      directory.rb
+      entry.rb
+      file_permission.rb
+      file_type.rb
+      formatter_factory.rb
+      long_formatter.rb
+      ls.rb
+      non_existent_container.rb
+      non_existent_formatter.rb
+      optional_parameter.rb
+      short_formatter.rb
+      statistics.rb
+      test
+      unrelated_file_container.rb
+    TEXT
+
+    opt_param = TestDoubleOptionalParameter.new(opt_a: false, opt_r: false, opt_l: false)
+    container = Directory.new('./')
+    container.generate_entries(opt_param)
+    short_formatter = FormatterFactory.create(container, opt_param)
+    short_formatter.send(:terminal_width_for_test, 50)
+
+    assert_equal(expected, short_formatter.generate_formatted_content)
+  end
+
+  test 'オプション指定（a）、パス指定（ディレクトリ）、列数（1）' do
+    expected = <<~TEXT.chomp
+      .
+      ..
+      .gitkeep
+      .rubocop.yml
+      Gemfile
+      Gemfile.lock
+      directory.rb
+      entry.rb
+      file_permission.rb
+      file_type.rb
+      formatter_factory.rb
+      long_formatter.rb
+      ls.rb
+      non_existent_container.rb
+      non_existent_formatter.rb
+      optional_parameter.rb
+      short_formatter.rb
+      statistics.rb
+      test
+      unrelated_file_container.rb
+    TEXT
+
+    opt_param = TestDoubleOptionalParameter.new(opt_a: true, opt_r: false, opt_l: false)
+    container = Directory.new('./')
+    container.generate_entries(opt_param)
+    short_formatter = FormatterFactory.create(container, opt_param)
+    short_formatter.send(:terminal_width_for_test, 50)
+
+    assert_equal(expected, short_formatter.generate_formatted_content)
+  end
+
+  test 'オプション指定（r）、パス指定（ディレクトリ）、列数（2）' do
+    expected = <<~TEXT.chomp
+      unrelated_file_container.rb long_formatter.rb
+      test                        formatter_factory.rb
+      statistics.rb               file_type.rb
+      short_formatter.rb          file_permission.rb
+      optional_parameter.rb       entry.rb
+      non_existent_formatter.rb   directory.rb
+      non_existent_container.rb   Gemfile.lock
+      ls.rb                       Gemfile
+    TEXT
+
+    opt_param = TestDoubleOptionalParameter.new(opt_a: false, opt_r: true, opt_l: false)
+    container = Directory.new('./')
+    container.generate_entries(opt_param)
+    short_formatter = FormatterFactory.create(container, opt_param)
+    short_formatter.send(:terminal_width_for_test, 80)
+
+    assert_equal(expected, short_formatter.generate_formatted_content)
+  end
+
+  test 'オプション指定（a,r）、パス指定（ディレクトリ）、列数（3）' do
+    expected = <<~TEXT.chomp
+      unrelated_file_container.rb ls.rb                       Gemfile.lock
+      test                        long_formatter.rb           Gemfile
+      statistics.rb               formatter_factory.rb        .rubocop.yml
+      short_formatter.rb          file_type.rb                .gitkeep
+      optional_parameter.rb       file_permission.rb          ..
+      non_existent_formatter.rb   entry.rb                    .
+      non_existent_container.rb   directory.rb
+    TEXT
+
+    opt_param = TestDoubleOptionalParameter.new(opt_a: true, opt_r: true, opt_l: false)
+    container = Directory.new('./')
+    container.generate_entries(opt_param)
+    short_formatter = FormatterFactory.create(container, opt_param)
+    short_formatter.send(:terminal_width_for_test, 100)
+
+    assert_equal(expected, short_formatter.generate_formatted_content)
+  end
+end

--- a/07.ls_object/test/test_short_formatter.rb
+++ b/07.ls_object/test/test_short_formatter.rb
@@ -104,11 +104,13 @@ class TestShortFormatter < Test::Unit::TestCase
       Gemfile.lock
       directory.rb
       entry.rb
+      extconf.rb
       file_permission.rb
       file_type.rb
       formatter_factory.rb
       long_formatter.rb
       ls.rb
+      macxattr.c
       non_existent_container.rb
       non_existent_formatter.rb
       optional_parameter.rb
@@ -137,11 +139,13 @@ class TestShortFormatter < Test::Unit::TestCase
       Gemfile.lock
       directory.rb
       entry.rb
+      extconf.rb
       file_permission.rb
       file_type.rb
       formatter_factory.rb
       long_formatter.rb
       ls.rb
+      macxattr.c
       non_existent_container.rb
       non_existent_formatter.rb
       optional_parameter.rb
@@ -166,9 +170,10 @@ class TestShortFormatter < Test::Unit::TestCase
       test                        formatter_factory.rb
       statistics.rb               file_type.rb
       short_formatter.rb          file_permission.rb
-      optional_parameter.rb       entry.rb
-      non_existent_formatter.rb   directory.rb
-      non_existent_container.rb   Gemfile.lock
+      optional_parameter.rb       extconf.rb
+      non_existent_formatter.rb   entry.rb
+      non_existent_container.rb   directory.rb
+      macxattr.c                  Gemfile.lock
       ls.rb                       Gemfile
     TEXT
 
@@ -188,8 +193,9 @@ class TestShortFormatter < Test::Unit::TestCase
       statistics.rb               formatter_factory.rb        .rubocop.yml
       short_formatter.rb          file_type.rb                .gitkeep
       optional_parameter.rb       file_permission.rb          ..
-      non_existent_formatter.rb   entry.rb                    .
-      non_existent_container.rb   directory.rb
+      non_existent_formatter.rb   extconf.rb                  .
+      non_existent_container.rb   entry.rb
+      macxattr.c                  directory.rb
     TEXT
 
     opt_param = TestDoubleOptionalParameter.new(opt_a: true, opt_r: true, opt_l: false)

--- a/07.ls_object/unrelated_file_container.rb
+++ b/07.ls_object/unrelated_file_container.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class UnrelatedFileContainer
+  def initialize(file_paths)
+    @paths = file_paths
+  end
+
+  def generate_list_content(opt_param)
+  end
+end

--- a/07.ls_object/unrelated_file_container.rb
+++ b/07.ls_object/unrelated_file_container.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
+require_relative 'entry'
+
 class UnrelatedFileContainer
   def initialize(file_paths)
     @paths = file_paths
   end
 
   def generate_list_content(opt_param)
+    @entries = @paths.map { |path| Entry.new(path) }
   end
 end

--- a/07.ls_object/unrelated_file_container.rb
+++ b/07.ls_object/unrelated_file_container.rb
@@ -15,11 +15,7 @@ class UnrelatedFileContainer
 
   def generate_entries(opt_param)
     row_entries = @paths.map { |path| Entry.new(path) }
-    @entries =
-      if opt_param.sort_reverse?
-        row_entries.sort_by(&:display_name).reverse
-      else
-        row_entries.sort_by(&:display_name)
-      end
+    sorted_entries = row_entries.sort_by(&:display_name)
+    @entries = opt_param.sort_reverse? ? sorted_entries.reverse : sorted_entries
   end
 end

--- a/07.ls_object/unrelated_file_container.rb
+++ b/07.ls_object/unrelated_file_container.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative 'entry'
-require_relative 'formatter_factory'
 
 class UnrelatedFileContainer
   attr_reader :entries
@@ -10,19 +9,13 @@ class UnrelatedFileContainer
     @paths = file_paths
   end
 
-  def generate_list_content(opt_param)
-    @entries = generate_entries_by_options(opt_param)
-    FormatterFactory.create(self, opt_param).generate_formatted_content
-  end
-
-  private
-
-  def generate_entries_by_options(opt_param)
-    entries = @paths.map { |path| Entry.new(path) }
-    if opt_param.sort_reverse?
-      entries.sort_by(&:display_name).reverse
-    else
-      entries.sort_by(&:display_name)
-    end
+  def generate_entries(opt_param)
+    row_entries = @paths.map { |path| Entry.new(path) }
+    @entries =
+      if opt_param.sort_reverse?
+        row_entries.sort_by(&:display_name).reverse
+      else
+        row_entries.sort_by(&:display_name)
+      end
   end
 end

--- a/07.ls_object/unrelated_file_container.rb
+++ b/07.ls_object/unrelated_file_container.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'entry'
+require_relative 'formatter_factory'
 
 class UnrelatedFileContainer
   attr_reader :entries
@@ -10,7 +11,18 @@ class UnrelatedFileContainer
   end
 
   def generate_list_content(opt_param)
-    @entries = @paths.map { |path| Entry.new(path) }
-    FormatterFactory.create(opt_param).generate_formatted_content(self, opt_param)
+    @entries = generate_entries_by_options(opt_param)
+    FormatterFactory.create(self, opt_param).generate_formatted_content
+  end
+
+  private
+
+  def generate_entries_by_options(opt_param)
+    entries = @paths.map { |path| Entry.new(path) }
+    if opt_param.sort_reverse?
+      entries.sort_by(&:display_name).reverse
+    else
+      entries.sort_by(&:display_name)
+    end
   end
 end

--- a/07.ls_object/unrelated_file_container.rb
+++ b/07.ls_object/unrelated_file_container.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
 require_relative 'entry'
+require_relative 'statistics'
 
 class UnrelatedFileContainer
-  attr_reader :entries
+  include Statistics
+
+  attr_reader :entries, :disp_total
 
   def initialize(file_paths)
     @paths = file_paths
+    @disp_total = false
   end
 
   def generate_entries(opt_param)

--- a/07.ls_object/unrelated_file_container.rb
+++ b/07.ls_object/unrelated_file_container.rb
@@ -3,11 +3,14 @@
 require_relative 'entry'
 
 class UnrelatedFileContainer
+  attr_reader :entries
+
   def initialize(file_paths)
     @paths = file_paths
   end
 
   def generate_list_content(opt_param)
     @entries = @paths.map { |path| Entry.new(path) }
+    FormatterFactory.create(opt_param).generate_formatted_content(self, opt_param)
   end
 end


### PR DESCRIPTION
「ls コマンドを作るオブジェクト指向版」の課題をpush致しました。

## 拡張ライブラリの使用手順
以前のlsコマンドのプラクティス（非オブジェクト指向版）で`macOSの拡張属性取得`に対応していました。
対応にはC拡張ライブラリを使用しており、使用には以下の手順が必要となります。🙏
1. Makefileを作成
```
$ ruby extconf.rb
```
2. make, make intallの実行
```
$ make
$ make install
```

## 自動テスト
- `07.ls_object`ディレクトリでの実行を想定しています。
- また、`test/test_short_formatter.rb`については、`07.ls_object`ディレクトリに以下のファイルが存在する前提で通る作りとなっています。（ファイルが多くても、少なくても失敗します💦）
```
.
..
.gitkeep
.rubocop.yml
Gemfile
Gemfile.lock
directory.rb
entry.rb
extconf.rb
file_permission.rb
file_type.rb
formatter_factory.rb
long_formatter.rb
ls.rb
macxattr.c
non_existent_container.rb
non_existent_formatter.rb
optional_parameter.rb
short_formatter.rb
statistics.rb
test
unrelated_file_container.rb
```

以上、ご確認よろしくお願い致します。🙇‍♂️